### PR TITLE
Allow serving local static files from catnip server itself using /files virtual directory.

### DIFF
--- a/src/catnip/pathtransformhandler.clj
+++ b/src/catnip/pathtransformhandler.clj
@@ -1,0 +1,45 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this file,
+;; You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(ns catnip.pathtransformhandler
+  (:require [clojure.string :as str])
+  (:import [org.webbitserver HttpHandler]
+           [java.net URI]))
+
+(defn- transform-path [path from to]
+  (str/replace path from to))
+
+(defn- transform-url [url from to]
+  (let [uri (URI. url)
+        path (.getPath uri)
+        new-path (transform-path path from to)]
+       (if (= path new-path)
+           url
+           (.toString (URI. 
+             (.getScheme uri)
+             (.getUserInfo uri)
+             (.getHost uri)
+             (.getPort uri)
+             new-path
+             (.getQuery uri)
+             (.getFragment uri))))))
+
+; Examples:
+#_(transform-url "/files/default.htm" #"/files(/.*)" "$1")
+#_(transform-url "http://localhost:11/files/default.htm" #"/files(/.*)" "$1")
+
+(defn- transform-req [req from to]
+  (let [uri (.uri req)
+        new-uri (transform-url uri from to)
+        transformed (not= new-uri uri)]
+       (when transformed
+         (.uri req new-uri))
+       transformed))
+
+(defn path-transform-handler [from to handler]
+  (proxy [HttpHandler] []
+    (handleHttpRequest [req res ctl]
+      (if (transform-req req from to)
+        (.handleHttpRequest handler req res ctl)
+        (.nextHandler ctl)))))

--- a/src/catnip/server.clj
+++ b/src/catnip/server.clj
@@ -10,10 +10,11 @@
             [catnip.repl :as repl]
             [catnip.complete :as complete]
             [clojure.repl])
-  (:use [clojure.test])
+  (:use [clojure.test]
+        [catnip.pathtransformhandler])
   (:import [org.webbitserver WebServer WebServers WebSocketHandler
             HttpHandler]
-           [org.webbitserver.handler EmbeddedResourceHandler]
+           [org.webbitserver.handler EmbeddedResourceHandler StaticFileHandler]
            [java.net InetSocketAddress URI]
            [java.util.concurrent Executors]))
 
@@ -92,6 +93,7 @@
               (handleHttpRequest [req res ctl]
                 (send-index res))))
       (.add (EmbeddedResourceHandler. "catnip"))
+      (.add (path-transform-handler #"/files(/.*)" "$1" (StaticFileHandler. ".")))
       (.start))
     (def ^:dynamic *server* server)
     (.getUri server)))


### PR DESCRIPTION
This is useful when working on a pure ClojureScript project.
Assuming there is default.htm file in project root dir, simply enter:
http://localhost:12345/files/default.htm in Catnip's browser frame.
Every time you recompile (save) a .cljs file the frame will refresh to reflect the results.
And no additional/standalone http server is necessary.
